### PR TITLE
Fix some breakage introduced with FontAwesome 5

### DIFF
--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -2,130 +2,130 @@
 id = "email"
 url = "mailto:%s"
 title = "Email me"
-icon = "fa-envelope"
+icon = "fa fa-envelope"
 
 [[social_icons]]
 id = "facebook"
 url = "https://www.facebook.com/%s"
 title = "Facebook"
-icon = "fa-facebook"
+icon = "fab fa-facebook"
 
 [[social_icons]]
 id = "googleplus"
 url = "https://plus.google.com/%s"
 title = "Google+"
-icon = "fa-google-plus"
+icon = "fab fa-google-plus"
 
 [[social_icons]]
 id = "github"
 url = "https://github.com/%s"
 title = "GitHub"
-icon = "fa-github"
+icon = "fab fa-github"
 
 [[social_icons]]
 id = "gitlab"
 url = "https://gitlab.com/%s"
 title = "GitLab"
-icon = "fa-gitlab"
+icon = "fab fa-gitlab"
 
 [[social_icons]]
 id = "bitbucket"
 url = "https://bitbucket.org/%s"
 title = "Bitbucket"
-icon = "fa-bitbucket"
+icon = "fab fa-bitbucket"
 
 [[social_icons]]
 id = "twitter"
 url = "https://twitter.com/%s"
 title = "Twitter"
-icon = "fa-twitter"
+icon = "fab fa-twitter"
 
 [[social_icons]]
 id = "reddit"
 url = "https://reddit.com/u/%s"
 title = "Reddit"
-icon = "fa-reddit-alien"
+icon = "fab fa-reddit-alien"
 
 [[social_icons]]
 id = "linkedin"
 url = "https://linkedin.com/in/%s"
 title = "LinkedIn"
-icon = "fa-linkedin"
+icon = "fab fa-linkedin"
 
 [[social_icons]]
 id = "xing"
 url = "https://www.xing.com/profile/%s"
 title = "Xing"
-icon = "fa-xing"
+icon = "fab fa-xing"
 
 [[social_icons]]
 id = "stackoverflow"
 url = "https://stackoverflow.com/%s"
 title = "StackOverflow"
-icon = "fa-stack-overflow"
+icon = "fab fa-stack-overflow"
 
 [[social_icons]]
 id = "snapchat"
 url = "https://www.snapchat.com/add/%s"
 title = "Snapchat"
-icon = "fa-snapchat-ghost"
+icon = "fab fa-snapchat-ghost"
 
 [[social_icons]]
 id = "instagram"
 url = "https://www.instagram.com/%s"
 title = "Instagram"
-icon = "fa-instagram"
+icon = "fab fa-instagram"
 
 [[social_icons]]
 id = "youtube"
 url = "https://www.youtube.com/%s"
 title = "Youtube"
-icon = "fa-youtube"
+icon = "fab fa-youtube"
 
 [[social_icons]]
 id = "soundcloud"
 url = "https://soundcloud.com/%s"
 title = "SoundCloud"
-icon = "fa-soundcloud"
+icon = "fab fa-soundcloud"
 
 [[social_icons]]
 id = "spotify"
 url = "https://open.spotify.com/user/%s"
 title = "Spotify"
-icon = "fa-spotify"
+icon = "fab fa-spotify"
 
 [[social_icons]]
 id = "bandcamp"
 url = "https://%s.bandcamp.com/"
 title = "Bandcamp"
-icon = "fa-bandcamp"
+icon = "fab fa-bandcamp"
 
 [[social_icons]]
 id = "itchio"
 url = "https://itch.io/profile/%s"
 title = "Itch.io"
-icon = "fa-gamepad"
+icon = "fab fa-gamepad"
 
 [[social_icons]]
 id = "keybase"
 url = "https://keybase.io/%s"
 title = "Keybase"
-icon = "fa-key"
+icon = "fab fa-key"
 
 [[social_icons]]
 id = "vk"
 url = "https://vk.com/%s"
 title = "VK"
-icon = "fa-vk"
+icon = "fab fa-vk"
 
 [[social_icons]]
 id = "paypal"
 url = "https://paypal.me/%s"
 title = "PayPal"
-icon = "fa-paypal"
+icon = "fab fa-paypal"
 
 [[social_icons]]
 id = "telegram"
 url = "https://telegram.me/%s"
 title = "Telegram"
-icon = "fa-telegram"
+icon = "fab fa-telegram"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
                 <a href="{{ printf .url (index $.Site.Author .id) }}" title="{{ .title }}">
                   <span class="fa-stack fa-lg">
                     <i class="fa fa-circle fa-stack-2x"></i>
-                    <i class="fa {{ .icon }} fa-stack-1x fa-inverse"></i>
+                    <i class="{{ .icon }} fa-stack-1x fa-inverse"></i>
                   </span>
                 </a>
               </li>

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -6,7 +6,7 @@
        target="_blank" alt="" title="Share on Twitter">
         <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
+		<i class="fab fa-twitter fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>
@@ -16,7 +16,7 @@
     <a href="//plus.google.com/share?url={{ .Permalink }}" target="_blank" title="Share on Google Plus">
          <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-google-plus fa-stack-1x fa-inverse"></i>
+                <i class="fab fa-google-plus fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>
@@ -26,7 +26,7 @@
     <a href="//www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" title="Share on Facebook">
         <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
+                <i class="fab fa-facebook fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>
@@ -36,7 +36,7 @@
     <a href="//reddit.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on Reddit">
          <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-reddit fa-stack-1x fa-inverse"></i>
+                <i class="fab fa-reddit fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>
@@ -47,7 +47,7 @@
        title="Share on LinkedIn">
          <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-linkedin fa-stack-1x fa-inverse"></i>
+                <i class="fab fa-linkedin fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>
@@ -58,7 +58,7 @@
        title="Share on StumbleUpon">
         <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-stumbleupon fa-stack-1x fa-inverse"></i>
+                <i class="fab fa-stumbleupon fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>
@@ -69,7 +69,7 @@
        title="Share on Pinterest">
          <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa fa-pinterest fa-stack-1x fa-inverse"></i>
+                <i class="fab fa-pinterest fa-stack-1x fa-inverse"></i>
               </span>
     </a>
 </li>


### PR DESCRIPTION
Social Icons are mostly branded icons. FA 5 requires
them to carry the fab prefix.